### PR TITLE
Updated to use a binpac flowunit flow vs a binpac datagram flow.

### DIFF
--- a/src/opcua_binary-debug.pac
+++ b/src/opcua_binary-debug.pac
@@ -69,7 +69,7 @@
     }
 
     void printMsgType( Msg_Header *msg_header) {
-        switch (bytestringToUint32(msg_header->msg_type())) {
+        switch (uint8VectorToUint32(msg_header->msg_type())) {
             case HEL: printMsgHEL( msg_header->hel());
                       break;
             case ACK: printMsgACK( msg_header->ack());

--- a/src/opcua_binary-protocol.pac
+++ b/src/opcua_binary-protocol.pac
@@ -45,11 +45,12 @@
 # Note: The Token Id and Secure Channel Id are set during the OpenSecureChannel Service
 #       and referenced by down stream MSG and CLO message types.
 #
-type Msg_Header = record {
-    msg_type   : bytestring &length = 3;
-    is_final   : bytestring &length = 1;
+#type Msg_Header = record {
+type Msg_Header(is_orig: bool) = record {
+    msg_type   : uint8[3];
+    is_final   : uint8;
     msg_size   : uint32;
-    type       : case($context.flow.bytestring_to_uint32(msg_type)) of {
+    type       : case($context.flow.uint8_array_to_uint32(msg_type)) of {
         HEL  -> hel: Msg_HEL(this);
         ACK  -> ack: Msg_ACK(this);
         ERR  -> err: Msg_ERR(this);
@@ -58,7 +59,8 @@ type Msg_Header = record {
         CLO  -> clo: Msg_CLO(this);
         #RHE  -> rhe: Msg_RHE(this);
     };
-} &byteorder=littleendian;
+    unknown: bytestring &restofdata, &transient;
+} &byteorder=littleendian, &length=msg_size;
 
 type Msg_HEL(header: Msg_Header) = record {
     version       : uint32;
@@ -139,7 +141,3 @@ type Msg_Body(header: Msg_Header) = record {
     deliver: bool = $context.flow.deliver_Msg_Body(this);
 } &byteorder=littleendian;
 
-type OPCUA_Binary_PDU(is_orig: bool) = record {
-    msg_header: Msg_Header;
-	data: bytestring &restofdata;
-} &byteorder=littleendian;

--- a/src/opcua_binary.pac
+++ b/src/opcua_binary.pac
@@ -29,7 +29,7 @@ connection OPCUA_Binary_Conn(bro_analyzer: ZeekAnalyzer) {
 
 # Now we define the flow:
 flow OPCUA_Binary_Flow(is_orig: bool) {
-	datagram = OPCUA_Binary_PDU(is_orig) withcontext(connection, this);
+    flowunit = Msg_Header(is_orig) withcontext(connection, this);
 };
 
 %include opcua_binary-analyzer.pac


### PR DESCRIPTION
# Updates to implement `binpac flowunit flow` #

## 🗣 Description ##
The initial implementation of the parser used a binpac datagram flow definition which results in faster parsing, but does not support incremental input or buffering.  Given the OPC UA data in the provided pcap has data fragmented over multiple frames, the parser has been updated to use a binpac flowunit flow which buffers data when there is not enough to evaluate the record and dispatches data for evaluation when the threshold is reached

## 💭 Motivation and context ##

Fixes #4

## 🧪 Testing ##
Testing of the updated parser revealed an issue with the provided pcap that limited verification of the changes.  The updated parser successfully parsed the CreateSessionRequest (frames #9 and #10), but due to a TCP Spurious Retransmission at frame #26, parsing of the CreateSessionResponse caused the data to be undelivered (OPCUA_Binary_Analyzer::Undelivered(uint64_t seq, int len, bool orig)) which sets the had_gap flag.  Once this flag is set, further processing of data is disabled when new streams are delivered (OPCUA_Binary_Analyzer::DeliverStream(int len, const u_char* data, bool orig)).

Researching Zeek and TCP Spurious Retransmission turned up Zeek issue #1564 which explained that "Zeek assumes that the traffic that it parses is in the same order as it happened."  See the References section below for furhter details.  Additionally, reviewing the source code for some of the built-in parsers (RDP, SSH, SSL) showed the same code path when the had_gap flag is set.  It appears this behavior is normal for Zeek parsers

In an effort to verify the CreateSessionResponse parsing up to frame #26, temporary debug statements were put in place that showed the data being processed and buffered.

## Implementation ##
Implementing the binpac flowunit flow was not as simple as changing from a datagram reference to a flowunit reference in the opcua_binary.pac code base.  This small change would cause the binpac compiler to issue various errors such as "cannot determine initial buffer length for type", etc.  After much digging and gnashing of teeth, three areas in the binpac definitions were causing the compiler errors.

1. The compiler did not like the bytestring definitions of the msg_type and is_final fields in the Msg_Header record.  These fields were changed to be uint8[3] and uint8 which caused additional ripple effects throughout the code base.
2. The Msg_Header record required an &length definition based on the msg_size field from the header.
3. The compiler did not like specifying a &length definition on the OPCUA_Binary_PDU record.  This record has been removed and the Msg_Header record updated to take an is_orig: bool parameter.

References:
* https://github.com/zeek/binpac#flow
* https://github.com/cisagov/icsnpp-opcua-binary/blob/main/src/OPCUA_Binary.cc#L83-L88
* https://github.com/cisagov/icsnpp-opcua-binary/blob/main/src/OPCUA_Binary.cc#L60-L63
* https://github.com/zeek/zeek/issues/1564
* https://github.com/cisagov/icsnpp-opcua-binary/blob/main/src/opcua_binary.pac#L32