### PR TITLE
Updated so the logging of status code information is consistent across response header and service implementations.

### DIFF
--- a/scripts/types.zeek
+++ b/scripts/types.zeek
@@ -68,7 +68,7 @@ export {
         # Response Header
         res_hdr_timestamp             : time    &log &optional;
         res_hdr_request_handle        : count   &log &optional;
-        res_hdr_service_result        : count   &log &optional;
+        res_hdr_service_result_id     : string  &log &optional; # Link into StatusCodeDetail log
         res_hdr_service_diag_encoding : count   &log &optional;
         res_hdr_add_hdr_type_id       : count   &log &optional;
         res_hdr_add_hdr_enc_mask      : count   &log &optional;

--- a/src/req-res-header/opcua_binary-req_res_header_analyzer.pac
+++ b/src/req-res-header/opcua_binary-req_res_header_analyzer.pac
@@ -76,16 +76,15 @@
         double unix_timestamp = winFiletimeToUnixTime(res_hdr->timestamp());
         info->Assign(RES_HDR_TIMESTAMP_IDX, zeek::make_intrusive<zeek::TimeVal>(unix_timestamp));
         info->Assign(RES_HDR_HANDLE_IDX, zeek::val_mgr->Count(res_hdr->request_handle()));
-        info->Assign(RES_HDR_SERVICE_RESULT_IDX, zeek::val_mgr->Count(res_hdr->service_result()));
-        info->Assign(RES_HDR_SERVICE_DIAG_ENCODING_IDX, zeek::val_mgr->Count(res_hdr->service_diag()->encoding_mask()));
 
-        // If the status code is not "Good"; then log more detailed information
-        if (res_hdr->service_result() != StatusCode_Good_Key) {
-            uint32_t status_code_level = 0;
-            generateStatusCodeEvent(connection, info->GetField(OPCUA_ID_IDX), StatusCode_ResponseHeader_Key, res_hdr->service_result(), status_code_level);
-        }
+        // Service Result aka Status Code
+        uint32_t status_code_level = 0;
+        string service_result_idx = generateId();
+        info->Assign(RES_HDR_SERVICE_RESULT_IDX, zeek::make_intrusive<zeek::StringVal>(service_result_idx));
+        generateStatusCodeEvent(connection, info->GetField(RES_HDR_SERVICE_RESULT_IDX), StatusCode_ResponseHeader_Key, res_hdr->service_result(), status_code_level);
 
         // If there is DiagnosticInfo - then log the detailed information.
+        info->Assign(RES_HDR_SERVICE_DIAG_ENCODING_IDX, zeek::val_mgr->Count(res_hdr->service_diag()->encoding_mask()));
         uint32 innerDiagLevel = 0;
         if (res_hdr->service_diag()->encoding_mask() != 0x00) {
 


### PR DESCRIPTION
## 🗣 Description ##
Update so the logging of status code information is consistent across response header and service implementations.

## 💭 Motivation and context ##

Early implementations of logging status code information would only log status code details if the status code was anything other than 'GOOD'.  As parser development progressed and additional references of the status code type were revealed, it became apparent logging status code details needed to be refactored.

## 🧪 Testing ##
Verified usage various project packet captures.

