### PR TITLE
Replace port range in the dpd signature to use >= 1024

### DIFF
--- a/scripts/icsnpp/opcua-binary/dpd.sig
+++ b/scripts/icsnpp/opcua-binary/dpd.sig
@@ -1,7 +1,7 @@
 signature dpd_opcua {
   ip-proto == tcp
-  src-port == 1024-65535
-  dst-port == 1024-65535
+  src-port >= 1024
+  dst-port >= 1024
   payload /^\x48\x45\x4c/
   enable "ICSNPP_OPCUA_BINARY"
 }


### PR DESCRIPTION
Replace port range in the dpd signature to use >= 1024 instead of a 1024-65535 range, as discovered by @keithjjones and @JustinAzoff. Using the range generates thousands of signatures internally (thus increasing CPU usage), while using the >= just creates one.
