### PR TITLE
Default processing for type OpcUA_ObjectBody

### DIFF
--- a/src/types/opcua_binary-types.pac
+++ b/src/types/opcua_binary-types.pac
@@ -397,6 +397,7 @@ type OpcUA_ObjectBody(extension_object_id : uint32) = record {
         SimpleAttributeOperand -> simple_attribute_operand  : OpcUA_SimpleAttributeOperand;
         EventFilterResult      -> event_filter_result       : OpcUA_EventFilterResult;
         AggregateFilterResult  -> aggregate_filter_result   : OpcUA_AggregateFilterResult;
+        default                -> empty_object_body         : bytestring &length = length;
     };
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Modified the processing of the type OpcUA_ObjectBody to have default processing mapped to an empty object body.  This update allows for clean/default processing for extension object ids that have yet to be implemented.  Without this modification, an exception is thrown when processing extension object ids that still need to be implemented.

## 🧪 Testing ##
To validate this change, revert this modification and un-comment the debug statement in file `src/OPCUA_Binary.cc` that prints a debug message for exceptions during `DeliverStream` processing.  Run test file `./pcaps/open62541_read_service_test_data_with_history.pcap` through the parser to see the exception.  Put the modification back in place and verify the exception is no longer thrown.

