### PR TITLE
Modified to require zeek v5.2.0 or higher in order to install.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -8,4 +8,4 @@ credits = Kent Kvarfordt <kent.kvarfordt@inl.gov>
 tags =  opcua, opcua_binary, opc, ICS, CISA, INL, ICSNPP, icsnpp, zeek plugin, log writer, protocol analyzer
 depends =
   zkg >=2.0
-  zeek >=4.0.0
+  zeek >=5.2.0


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Modified the zkg.meta file to require zeek v5.2.0 or higher.

## 💭 Motivation and context ##
See issue #81.  Version 5.2.0 of zeek added the `AnalyzerViolation` method.  This method is causing the installation/build to fail when using earlier versions.

See the zeek releases (https://github.com/zeek/zeek/releases) for more information.

## 🧪 Testing ##

Verified `zkg install icsnpp-opcua-binary` works as expected when installing against the Ubuntu zeek-lts version - e.g. `sudo apt install zeek-lts`
