### PR TITLE
Modified printf formatting to remove compiler warnings/errors

### DIFF
--- a/src/types/opcua_binary-types_debug.pac
+++ b/src/types/opcua_binary-types_debug.pac
@@ -84,7 +84,7 @@
         printf("%s ViewId: NodeId\n", indent(indent_width + 1).c_str());
         printOpcUA_NodeId(indent_width + 2,viewInfo->view_id());
         if (viewInfo->timestamp() > 0){
-            printf("%s Timestamp: %lld\n", indent(indent_width + 1).c_str(), viewInfo->timestamp());
+            printf("%s Timestamp: %ld\n", indent(indent_width + 1).c_str(), viewInfo->timestamp());
         } else {
             printf("%s Timestamp: No time specified (0)\n", indent(indent_width + 1).c_str());
         }

--- a/src/types/variants/opcua_binary-variant_types_debug.pac
+++ b/src/types/variants/opcua_binary-variant_types_debug.pac
@@ -122,11 +122,11 @@
         }
 
         if (built_in_type == BuiltIn_Int64) {
-            printf("%s Int64: %lld\n", indent(indent_width).c_str(), obj->int64_variant());
+            printf("%s Int64: %ld\n", indent(indent_width).c_str(), obj->int64_variant());
         }
 
         if (built_in_type == BuiltIn_Uint64) {
-            printf("%s UInt64: %llu\n", indent(indent_width).c_str(), obj->uint64_variant());
+            printf("%s UInt64: %lu\n", indent(indent_width).c_str(), obj->uint64_variant());
         }
 
         if (built_in_type == BuiltIn_String) {


### PR DESCRIPTION
## 🗣 Description ##

Modified printf formatting to remove compiler warnings/errors when installing with zkg.

## 💭 Motivation and context ##

Reviewing the zkg build log file showed warnings/errors that were caused by printf formatting not lining up with the actual size of the variable being printed.

## 🧪 Testing ##
Verified the warnings/errors were no longer in the zkg build log file.