### PR TITLE
change comment format to avoid "discarded extraneous zeekygen comment" warnings

### DIFF
--- a/scripts/activate-session-types.zeek
+++ b/scripts/activate-session-types.zeek
@@ -1,14 +1,14 @@
-## activate-session-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! activate-session-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/browse-types.zeek
+++ b/scripts/browse-types.zeek
@@ -1,14 +1,14 @@
-## create-browse_view-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Melanie Pierce
-## Contact:  Melanie.Pierce@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! create-browse_view-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Melanie Pierce
+##! Contact:  Melanie.Pierce@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 

--- a/scripts/close-session-types.zeek
+++ b/scripts/close-session-types.zeek
@@ -1,14 +1,14 @@
-## close-session-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Christian Weelborg
-## Contact:  Christian.Weelborg@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! close-session-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Christian Weelborg
+##! Contact:  Christian.Weelborg@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/create-monitored-items-types.zeek
+++ b/scripts/create-monitored-items-types.zeek
@@ -1,14 +1,14 @@
-## create-monitored-items-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Melanie Pierce
-## Contact:  Melanie.Pierce@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! create-monitored-items-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Melanie Pierce
+##! Contact:  Melanie.Pierce@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 

--- a/scripts/create-session-types.zeek
+++ b/scripts/create-session-types.zeek
@@ -1,14 +1,14 @@
-## create-session-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! create-session-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/create-subscription-types.zeek
+++ b/scripts/create-subscription-types.zeek
@@ -1,14 +1,14 @@
-## create-subscription-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Melanie Pierce
-## Contact:  Melanie.Pierce@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! create-subscription-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Melanie Pierce
+##! Contact:  Melanie.Pierce@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/filter-types.zeek
+++ b/scripts/filter-types.zeek
@@ -1,14 +1,14 @@
-## filter-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Melanie Pierce
-## Contact:  Melanie.Pierce@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! filter-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Melanie Pierce
+##! Contact:  Melanie.Pierce@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/get-endpoints-types.zeek
+++ b/scripts/get-endpoints-types.zeek
@@ -1,14 +1,14 @@
-## get-endpoints-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! get-endpoints-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/icsnpp/opcua-binary/main.zeek
+++ b/scripts/icsnpp/opcua-binary/main.zeek
@@ -1,14 +1,14 @@
-## main.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Base script layer functionality for processing events emitted from
-## the analyzer.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! main.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Base script layer functionality for processing events emitted from
+##! the analyzer.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 

--- a/scripts/read-types.zeek
+++ b/scripts/read-types.zeek
@@ -1,14 +1,14 @@
-## read-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! read-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/secure-channel-types.zeek
+++ b/scripts/secure-channel-types.zeek
@@ -1,14 +1,14 @@
-## secure-channel-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! secure-channel-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/statuscode-diagnostic-types.zeek
+++ b/scripts/statuscode-diagnostic-types.zeek
@@ -1,14 +1,14 @@
-## statuscode-diagnostic-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! statuscode-diagnostic-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/types.zeek
+++ b/scripts/types.zeek
@@ -1,14 +1,14 @@
-## types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Kent Kvarfordt
-## Contact:  kent.kvarfordt@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Kent Kvarfordt
+##! Contact:  kent.kvarfordt@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {

--- a/scripts/variant-types.zeek
+++ b/scripts/variant-types.zeek
@@ -1,14 +1,14 @@
-## variant-types.zeek
-##
-## OPCUA Binary Protocol Analyzer
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Melanie Pierce
-## Contact:  melanie.pierce@inl.gov
-##
-## Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
+##! variant-types.zeek
+##!
+##! OPCUA Binary Protocol Analyzer
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Melanie Pierce
+##! Contact:  melanie.pierce@inl.gov
+##!
+##! Copyright (c) 2022 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module ICSNPP_OPCUA_Binary;
 export {


### PR DESCRIPTION
Changed some double-pound comments to double-pound-bash comments to avoid 'discarded extraneous zeekygen comment' warning, see [zeekygen/example.zeek](https://github.com/zeek/zeek/blob/master/scripts/zeekygen/example.zeek) for reference.

Every time I run zeek with this script installed, we see something like this warning:

```
warning in ..., line 1: Discarded extraneous Zeekygen comment: Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
```

If you read the file I linked, it talks about the difference between `#`, `##`, and `##!` comments.

This commit changes the `##` comments at the beginning of the file to `##!` comments.