### PR TITLE
Removed CloseSessionRequest and CloseSessionResponse 

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -157,7 +157,7 @@ The following table shows the services that have been stubbed out and currently 
 |                                         | `FindServersRequest`                    | `FindServersResponse`                   |
 | `FindServersOnNetworkRequest`           | `FindServersOnNetworkResponse`          | `RegisterServerRequest`                 |
 | `RegisterServerResponse`                | `RegisterServer2Request`                | `RegisterServer2Response`               |
-| `CloseSessionRequest`                   | `CloseSessionResponse`                  | `CancelRequest`                         |
+|                                         |                                         | `CancelRequest`                         |
 | `CancelResponse`                        | `AddNodesRequest`                       | `AddNodesResponse`                      |
 | `AddReferencesRequest`                  | `AddReferencesResponse`                 | `DeleteNodesRequest`                    |
 | `DeleteNodesResponse`                   | `DeleteReferencesRequest`               | `DeleteReferencesResponse`              |


### PR DESCRIPTION
Removed CloseSessionRequest and CloseSessionResponse from the table of services to implement as they have already been developed.

## 💭 Motivation and context ##
Keep the table of services to implement up to date