### PR TITLE
Code cleanup to aid maintenance

### DIFF
--- a/src/opcua_binary-protocol.pac
+++ b/src/opcua_binary-protocol.pac
@@ -66,7 +66,6 @@
 # Note: The Token Id and Secure Channel Id are set during the OpenSecureChannel Service
 #       and referenced by down stream MSG and CLO message types.
 #
-#type Msg_Header = record {
 type Msg_Header(is_orig: bool) = record {
     msg_type   : uint8[3];
     is_final   : uint8;

--- a/src/types/variants/opcua_binary-variant_types_analyzer.pac
+++ b/src/types/variants/opcua_binary-variant_types_analyzer.pac
@@ -20,13 +20,6 @@
         // Data Value Encoding Mask
         service_object->Assign(offset, zeek::make_intrusive<zeek::StringVal>(uint8ToHexstring(data_value->encoding_mask())));
 
-        // DataValue
-        if (data_value->has_value_case_index()) {
-            std::string service_object_variant_data_link_id = generateId();
-            service_object->Assign(offset + 6, zeek::make_intrusive<zeek::StringVal>(service_object_variant_data_link_id));
-            flattenOpcUA_DataVariant(connection, data_value->value(), service_object_variant_data_link_id, variant_source, is_orig);
-        }
-
         // StatusCode
         if (data_value->has_status_code_case_index()) {
             uint32_t status_code_level   = 0;
@@ -55,6 +48,13 @@
         // ServerPicoSeconds
         if (data_value->has_server_pico_sec_case_index()) {
             service_object->Assign(offset + 5, zeek::val_mgr->Count(data_value->server_pico_sec()));
+        }
+
+        // DataValue
+        if (data_value->has_value_case_index()) {
+            std::string service_object_variant_data_link_id = generateId();
+            service_object->Assign(offset + 6, zeek::make_intrusive<zeek::StringVal>(service_object_variant_data_link_id));
+            flattenOpcUA_DataVariant(connection, data_value->value(), service_object_variant_data_link_id, variant_source, is_orig);
         }
 
         return;


### PR DESCRIPTION
## 🗣 Description ##

Miscellaneous code clean up to help with maintainability.

## 💭 Motivation and context ##

`opcua_binary-variant_types_analyzer.pac`: Reordered the processing so the `offset + xxxx` are in sequential order
`opcua_binary-prototoal.pac`: Removed a commented out line.

## 🧪 Testing ##

Verified parser still compiles and runs.  Successfully executed `btest`

